### PR TITLE
Add support for Instagram hidecaption attribute

### DIFF
--- a/src/instagram.js
+++ b/src/instagram.js
@@ -13,7 +13,7 @@ CMS.registerEditorComponent({
         widget: "boolean"
       }
     ],
-    pattern: /{{< instagram ([a-zA-Z0-9]+) (hidecaption)?>}}/,
+    pattern: /{{< instagram ([a-zA-Z0-9]+)\s?(hidecaption)? >}}/,
     fromBlock: function(match) {
         return {
             pid: match[1],

--- a/src/instagram.js
+++ b/src/instagram.js
@@ -1,21 +1,33 @@
 CMS.registerEditorComponent({
     id: "instagram",
     label: "Instagram",
-    fields: [{
-        name: "pid",
-        label: "Post id",
-        widget: "string"
-    }],
-    pattern: /{{< instagram ([a-zA-Z0-9]+) >}}/,
+    fields: [
+      {
+          name: "pid",
+          label: "Post id",
+          widget: "string"
+      },
+      {
+        name: "hidecaption",
+        label: "Hidden caption",
+        widget: "boolean"
+      }
+    ],
+    pattern: /{{< instagram ([a-zA-Z0-9]+) (hidecaption)?>}}/,
     fromBlock: function(match) {
         return {
-            pid: match[1]
+            pid: match[1],
+            hidecaption: match[2]
         };
     },
     toBlock: function(obj) {
-        return `{{< instagram ${obj.pid} >}}`;
+        return `{{< instagram ${obj.pid} ${
+          obj.hidecaption ? "hidecaption" : ""
+        }>}}`;
     },
     toPreview: function(obj) {
-        return `{{< instagram ${obj.pid} >}}`;
+        return `{{< instagram ${obj.pid} ${
+          obj.hidecaption ? "hidecaption" : ""
+        }>}}`;
     },
 });

--- a/src/instagram.js
+++ b/src/instagram.js
@@ -9,11 +9,11 @@ CMS.registerEditorComponent({
       },
       {
         name: "hidecaption",
-        label: "Hidden caption",
+        label: "Hide caption",
         widget: "boolean"
       }
     ],
-    pattern: /{{< instagram ([a-zA-Z0-9]+)\s?(hidecaption)? >}}/,
+    pattern: /{{< instagram (?<pid>[a-zA-Z0-9]+)\s{0,}(?<hidecaption_flag>hidecaption)?\s+>}}/,
     fromBlock: function(match) {
         return {
             pid: match[1],


### PR DESCRIPTION
Adds a boolean for `hidecaption` in the Instagram widget as documented here: https://gohugo.io/content-management/shortcodes/#example-instagram-output