### PR TITLE
Bump GitHub action workflow to latest version

### DIFF
--- a/.github/workflows/merger.yml
+++ b/.github/workflows/merger.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run a multi-line script
       run: |
         mkdir -p dist

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
   <h1>Hugo Shortcodes for Netlify CMS editor</h1>
-<img src="https://forthebadge.com/images/badges/powered-by-responsibility.svg" width="250">
-<img src="https://forthebadge.com/images/badges/built-with-love.svg" width="150">
-<img src="https://forthebadge.com/images/badges/made-with-javascript.svg" width="250">
+<img src="https://web.archive.org/web/20230730063628if_/https://forthebadge.com/images/badges/powered-by-responsibility.svg" width="250">
+<img src="https://web.archive.org/web/20230730063628if_/https://forthebadge.com/images/badges/built-with-love.svg" width="150">
+<img src="https://web.archive.org/web/20230730063628if_/https://forthebadge.com/images/badges/made-with-javascript.svg" width="250">
 </div>  
 
 ---


### PR DESCRIPTION
This PR corrects broken image links in `README.md`. It also bumps the `checkout` action to its  latest version.